### PR TITLE
CI: run dependency install and Strapi build only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,19 @@
-name: Deploy
+name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - master
 
-env:
-  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
 jobs:
-  deploy:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## Summary
- replace the current deploy workflow with a lightweight CI job
- run `npm ci` and `npm run build` on pull requests and pushes to `master`
- remove Fly.io deployment step and deploy token dependency from CI checks