### PR TITLE
chore: govern Dependabot PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    groups:
+      npm-patch-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` for the npm ecosystem with a daily schedule
- cap open Dependabot PRs at 5 to reduce backlog noise
- group patch and minor updates into a single stream to keep PR volume manageable