### PR TITLE
Docs: unify skeleton README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,57 @@
-# Strapi
+# Strapi v4 skeleton
 
-[Strapi](https://strapi.io/) - Open Source Node.js Headless CMS
+A Strapi 4 application skeleton with SQLite, MariaDB, or PostgreSQL database support.
 
-## Stack
+## Requirements
 
-- Strapi 4+
-- Node.js 18+
-- MariaDB 10.10+
-- SQLite (for development)
+- Node.js 18.x
+- npm 9 or newer
+- Docker and Docker Compose (optional, for database services)
+
+## Create a project
+
+Clone this repository or use it as a GitHub template, then install the locked dependencies:
+
+```bash
+git clone https://github.com/contributte/strapi-v4-skeleton.git acme
+cd acme
+cp .env.example .env
+npm ci
+```
+
+## Local development
+
+The example configuration uses SQLite. Its database is stored in `.tmp/data.db`; no database service is required.
+
+```bash
+make dev
+```
+
+Open the application at [http://localhost:1337](http://localhost:1337). Create the initial administrator account at [http://localhost:1337/admin](http://localhost:1337/admin).
+
+Use `make strapi-admin` to develop the admin UI, `make strapi-build` to build it, and `make start` to build and start Strapi.
+
+## Docker database services
+
+Docker Compose provides MariaDB, PostgreSQL, and Adminer; it does not run the Strapi application. Start the services with:
+
+```bash
+docker compose up -d
+```
+
+MariaDB is available on `localhost:3306`, PostgreSQL on `localhost:5432`, and Adminer at [http://localhost:8080](http://localhost:8080). Use `make docker-mariadb` to start only MariaDB.
+
+Run `make dev` separately to start Strapi. The `make docker-dev` target runs an already built application image and requires `DOCKER_IMAGE` to be set.
 
 ## Configuration
 
-We use these plugins in Strapi:
+Copy `.env.example` to `.env` and replace all placeholder secrets before deployment. Strapi reads the host and port from `HOST` and `PORT`; `DOMAIN` is used by plugin configuration.
 
-- upload ([aws-s3](https://www.npmjs.com/package/@strapi/provider-upload-aws-s3))
-- email ([nodemail](https://www.npmjs.com/package/@strapi/provider-email-sendmail))
-- sentry ([sentry](https://www.npmjs.com/package/@strapi/plugin-sentry))
+Set `DATABASE_TYPE` to one of `sqlite`, `mysql`, or `postgres`:
 
-## Development
+- `sqlite` uses `DATABASE_FILENAME` (default: `.tmp/data.db`) and does not use `DATABASE_URL`.
+- `mysql` and `postgres` require `DATABASE_URL` in the matching connection-string format, such as `mysql://strapi:strapi@127.0.0.1:3306/strapi` or `postgres://postgres:strapi@127.0.0.1:5432/strapi`.
 
-**Makefile**
+The Compose MariaDB service provides the `strapi` database and `strapi`/`strapi` credentials. The PostgreSQL service provides the `strapi` database and the `postgres` user with password `strapi`. Set `DATABASE_SSL=true` only when the database connection requires TLS.
 
-```
-➜ make
-Usage:
-  make <target>
-
-Targets:
-  clean                Clean strapi files
-  dev                  Start Strapi for local development
-  docker-build         Docker image build
-  docker-dev           Run docker image
-  docker-mariadb       Run mariadb container
-  docker-push          Push docker image to registry
-  docker-up            Run docker containers
-  install              Install all dependencies
-  start                Strapi start sequence (build + start)
-  strapi-admin         Strapi GUI development
-  strapi-build         Build Strapi CMS
-```
-
-**ENV**
-
-```env
-# Strapi
-HOST=0.0.0.0
-PORT=1337
-DOMAIN=http://localhost:1337
-APP_KEYS=strapi
-API_TOKEN_SALT=strapi
-ADMIN_JWT_SECRET=strapi
-JWT_SECRET=strapi
-
-# Database
-DATABASE_TYPE=sqlite
-DATABASE_URL=postgres://postgres:strapi@0.0.0.0:5432/strapi
-
-# S3
-S3_ENABLED=false
-S3_ACCESS_KEY_ID=strapi
-S3_ACCESS_SECRET=strapi
-S3_ENDPOINT=https://s3.yourserver
-S3_BUCKET=strapi
-
-# Emails
-SMTP_ENABLED=false
-SMTP_HOST=smtp.yourserver
-SMTP_PORT=587
-SMTP_USERNAME=
-SMTP_PASSWORD=
-
-# Sentry
-SENTRY_ENABLED=false
-SENTRY_DSN=sentry
-
-```
+Optional S3, SMTP, and Sentry integrations are controlled by their respective `*_ENABLED` variables in `.env`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ make dev
 
 Open the application at [http://localhost:1337](http://localhost:1337). Create the initial administrator account at [http://localhost:1337/admin](http://localhost:1337/admin).
 
-Use `make strapi-admin` to develop the admin UI, `make strapi-build` to build it, and `make start` to build and start Strapi.
+## Commands
+
+```bash
+make install       # install locked dependencies
+make dev           # run Strapi in development mode
+make strapi-build  # build the Strapi admin
+make start         # build and start Strapi
+```
 
 ## Docker database services
 
@@ -39,19 +46,27 @@ Docker Compose provides MariaDB, PostgreSQL, and Adminer; it does not run the St
 docker compose up -d
 ```
 
-MariaDB is available on `localhost:3306`, PostgreSQL on `localhost:5432`, and Adminer at [http://localhost:8080](http://localhost:8080). Use `make docker-mariadb` to start only MariaDB.
+MariaDB is available on `localhost:3306`, PostgreSQL on `localhost:5432`, and Adminer at [http://localhost:8080](http://localhost:8080).
 
 Run `make dev` separately to start Strapi. The `make docker-dev` target runs an already built application image and requires `DOCKER_IMAGE` to be set.
 
 ## Configuration
 
-Copy `.env.example` to `.env` and replace all placeholder secrets before deployment. Strapi reads the host and port from `HOST` and `PORT`; `DOMAIN` is used by plugin configuration.
+Copy `.env.example` to `.env`. Its values, including all sample secrets and credentials, are for development only and must be replaced for deployment.
+
+### Application
+
+Strapi reads the host and port from `HOST` and `PORT`; `APP_KEYS`, `API_TOKEN_SALT`, `ADMIN_JWT_SECRET`, and `JWT_SECRET` configure application and authentication secrets. `DOMAIN` is available to plugin configuration.
+
+### Database
 
 Set `DATABASE_TYPE` to one of `sqlite`, `mysql`, or `postgres`:
 
 - `sqlite` uses `DATABASE_FILENAME` (default: `.tmp/data.db`) and does not use `DATABASE_URL`.
 - `mysql` and `postgres` require `DATABASE_URL` in the matching connection-string format, such as `mysql://strapi:strapi@127.0.0.1:3306/strapi` or `postgres://postgres:strapi@127.0.0.1:5432/strapi`.
 
-The Compose MariaDB service provides the `strapi` database and `strapi`/`strapi` credentials. The PostgreSQL service provides the `strapi` database and the `postgres` user with password `strapi`. Set `DATABASE_SSL=true` only when the database connection requires TLS.
+The Compose MariaDB service provides the `strapi` database and `strapi`/`strapi` credentials. The PostgreSQL service provides the `strapi` database and the `postgres` user with password `strapi`. These Compose credentials are development-only. Set `DATABASE_SSL=true` only when the database connection requires TLS.
 
-Optional S3, SMTP, and Sentry integrations are controlled by their respective `*_ENABLED` variables in `.env`.
+### Optional integrations
+
+S3 uploads, SMTP email, and Sentry are disabled unless their respective `S3_ENABLED`, `SMTP_ENABLED`, and `SENTRY_ENABLED` variables are enabled in `.env`; configure their matching variables before enabling them.


### PR DESCRIPTION
## Scope

Unifies README onboarding with the current Strapi v4 skeleton: installation, local and Docker database workflows, service URLs, and database/environment configuration. Removes the incoherent SQLite/PostgreSQL example.

## Validation

- `git diff --check` passed.